### PR TITLE
remove setuptools from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ authors = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "setuptools>=75.3.0",
 ]
 classifiers=[   
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
It is not needed since https://github.com/AnirudhG07/Typeinc/pull/5 was merged.